### PR TITLE
Add Express server and startup script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.env
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "itanimulli",
+  "version": "1.0.0",
+  "description": "Pequeño juego tipo runner hecho en HTML5 Canvas.",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "express": "^4.18.2"
+  },
+  "type": "commonjs"
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,15 @@
+const express = require('express');
+const path = require('path');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.use(express.static(__dirname));
+
+app.get('/', (req, res) => {
+  res.sendFile(path.join(__dirname, 'index.html'));
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add minimal Express server to serve index.html, style.css, and game.js
- add start script to package.json
- ignore node_modules and environment variables

## Testing
- `node server.js` *(fails: Cannot find module 'express'; npm install blocked by 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b64ca7a69c83209b90bf655e1c4309