### PR TITLE
Add black hole transition to dream cycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Runner: Ángeles y Sombras
+# ITANIMULLI
 
 Pequeño juego tipo *runner* hecho en HTML5 Canvas, inspirado en la idea de un corredor que evita enemigos (reptilianos, ángeles y triángulos con ojo) al estilo sencillo del dinosaurio de Google.
 
@@ -14,6 +14,10 @@ Pequeño juego tipo *runner* hecho en HTML5 Canvas, inspirado en la idea de un c
 - **Desde 60 s** la dificultad aumenta un poco más y cada **60 s (60/120/180)** recibes **alas durante 15 s** que desbloquean un salto extra temporal.
 - **Ángeles** disparan **misiles dirigidos al muslo derecho** del jugador; los **ojos con alas** hacen daño por contacto.
 - **Reptilianos** corren por el suelo en dirección opuesta. Cualquier contacto con **misil/ láser/ ojo con alas/ reptiliano** te hace perder una vida.
+
+## Ciclos y transición
+- El juego inicia en una carretera arcade con suelo gris y líneas amarillas.
+- Al completar el primer ciclo, un **agujero negro** absorbe a los enemigos y da paso a un segundo entorno onírico con suelo púrpura y partículas flotantes.
 
 ## Ejecutar
 Basta con abrir `index.html` en cualquier navegador moderno (Chrome/Edge/Firefox/Safari). No requiere servidor ni recursos externos.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Pequeño juego tipo *runner* hecho en HTML5 Canvas, inspirado en la idea de un c
 
 ## Ciclos y transición
 - El juego inicia en una carretera arcade con suelo gris y líneas amarillas.
-- Al completar el primer ciclo, un **agujero negro** absorbe a los enemigos y da paso a un segundo entorno onírico con suelo púrpura y partículas flotantes.
+- Al completar el primer ciclo, un **agujero negro** absorbe a los enemigos y da paso a un segundo entorno onírico: cielo en degradado violeta-azul con galaxias y una luna alienígena, suelo púrpura con grietas luminosas y partículas que flotan hacia arriba.
 
 ## Ejecutar
 Basta con abrir `index.html` en cualquier navegador moderno (Chrome/Edge/Firefox/Safari). No requiere servidor ni recursos externos.

--- a/game.js
+++ b/game.js
@@ -1031,16 +1031,14 @@
     if (cycle === 0) {
       ctx.fillStyle = '#2C2C2C';
       ctx.fillRect(0, groundY(), W, H-groundY());
-      ctx.strokeStyle = '#FFDD00';
-      ctx.lineWidth = 4;
-      ctx.setLineDash([40,40]);
-      ctx.beginPath();
-      for (let x = -(time*speed)%80; x < W; x += 80) {
-        ctx.moveTo(x, groundY()+2);
-        ctx.lineTo(x+40, groundY()+2);
+      const laneY = groundY() + (H - groundY()) / 2;
+      const dashLen = 40;
+      const gap = 40;
+      const offset = -(time * speed) % (dashLen + gap);
+      ctx.fillStyle = '#FFDD00';
+      for (let x = offset; x < W; x += dashLen + gap) {
+        ctx.fillRect(x, laneY - 4, dashLen, 8);
       }
-      ctx.stroke();
-      ctx.setLineDash([]);
     } else {
       ctx.fillStyle = '#302138';
       ctx.fillRect(0, groundY(), W, H-groundY());

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="mobile-web-app-capable" content="yes">
-  <title>Runner: Ángeles y Sombras</title>
+  <title>ITANIMULLI</title>
   <link rel="stylesheet" href="style.css">
   <link rel="icon" type="image/png" sizes="192x192" href="/logo.png">
   <link rel="apple-touch-icon" sizes="192x192" href="/logo.png">
@@ -14,7 +14,7 @@
 <body>
   <canvas id="game"></canvas>
   <div id="overlay">
-    <h1>RUNNER: ÁNGELES Y SOMBRAS</h1>
+    <h1>ITANIMULLI</h1>
     <p class="subtitle">Evita misiles, rayos y reptilianos. Sobrevive el mayor tiempo posible.</p>
     <div class="stats">
       <div>Récord: <span id="best">0.0</span>s</div>


### PR DESCRIPTION
## Summary
- Implement black hole transition between arcade and dream cycles
- Render gray road with dashed yellow lines in cycle 1 and purple dreamscape with floating particles in cycle 2
- Document cycle change in README

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b86c2dadcc8320901580b423883ff4