### PR TITLE
Define cycle before canvas resizing to avoid early errors

### DIFF
--- a/game.js
+++ b/game.js
@@ -12,6 +12,10 @@
   const isTouchDevice = window.matchMedia('(pointer: coarse)').matches;
   const SCALE = isTouchDevice ? 0.8 : 1;
 
+  // Control de ciclos del juego
+  let cycleStart = 0;
+  let cycle = 0;
+
   let W = 0, H = 0;
   function resizeCanvas() {
     const dpr = Math.max(1, window.devicePixelRatio || 1);
@@ -97,8 +101,6 @@
   const cosmics = [];
   let missileHomingToggle = false;
   let apocalypseTriggered = false;
-  let cycleStart = 0;
-  let cycle = 0;
 
 
   // Spawners control


### PR DESCRIPTION
## Summary
- Declare `cycle` and `cycleStart` before `resizeCanvas` to ensure they exist when the function runs

## Testing
- `npm start` (server starts)
- `npm install jsdom@22.1.0` (fails: 403 Forbidden)

------
https://chatgpt.com/codex/tasks/task_e_68b993025df08320bbcc6046067963c6