### PR TITLE
Add parallax mountains and textured ground background

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,107 @@
+const Bg = (() => {
+  let layers = [];
+  let groundPatternCanvas, groundPattern;
+  let groundPatternSize = 64;
+  let canvasW = 0, canvasH = 0;
+  let mainCanvas;
+  let lowRes = false;
+
+  function initBackgroundLayers(canvas) {
+    mainCanvas = canvas;
+    canvasW = canvas.width;
+    canvasH = canvas.height;
+    createGroundPattern();
+    createLayers();
+  }
+
+  function createGroundPattern() {
+    const size = lowRes ? 32 : 64;
+    groundPatternSize = size;
+    groundPatternCanvas = document.createElement('canvas');
+    groundPatternCanvas.width = groundPatternCanvas.height = size;
+    const c = groundPatternCanvas.getContext('2d');
+    c.fillStyle = '#4a2e3b';
+    c.fillRect(0, 0, size, size);
+    for (let i = 0; i < 50; i++) {
+      c.fillStyle = Math.random() < 0.5 ? '#6b7c6b' : '#7a7a7a';
+      c.fillRect(Math.random() * size, Math.random() * size, 2, 2);
+    }
+    groundPattern = c.createPattern(groundPatternCanvas, 'repeat');
+  }
+
+  function createLayers() {
+    const gY = typeof groundY === 'function' ? groundY() : canvasH * 0.82;
+    layers = [
+      createMountains('#362640', '#432e54', gY * 0.4, 0.1),
+      createMountains('#4a335e', '#5a3d75', gY * 0.5, 0.3),
+      createMountains('#6a437c', '#7d4e94', gY * 0.6, 0.6)
+    ];
+  }
+
+  function createMountains(color1, color2, height, speed) {
+    const scale = lowRes ? 0.5 : 1;
+    const off = document.createElement('canvas');
+    off.width = canvasW * scale;
+    off.height = height * scale;
+    const c = off.getContext('2d');
+    c.scale(scale, scale);
+    const grad = c.createLinearGradient(0, 0, 0, height);
+    grad.addColorStop(0, color1);
+    grad.addColorStop(1, color2);
+    c.fillStyle = grad;
+    c.beginPath();
+    c.moveTo(0, height);
+    const step = canvasW / 5;
+    for (let x = 0; x <= canvasW; x += step) {
+      const peak = height - Math.random() * height * 0.8;
+      c.lineTo(x, peak);
+    }
+    c.lineTo(canvasW, height);
+    c.closePath();
+    c.fill();
+    return { canvas: off, height, width: canvasW, speed, x: 0 };
+  }
+
+  function updateBackground(dt) {
+    const s = (typeof window !== 'undefined' && typeof window._gameSpeed === 'function') ? window._gameSpeed() : 1;
+    layers.forEach(l => {
+      l.x -= s * dt * l.speed;
+      if (l.x <= -l.width) l.x += l.width;
+    });
+    offsets.ground -= s * dt;
+    if (offsets.ground <= -groundPatternSize) offsets.ground += groundPatternSize;
+    if (!lowRes && dt > 0.05) { lowRes = true; initBackgroundLayers(mainCanvas); }
+    else if (lowRes && dt < 0.035) { lowRes = false; initBackgroundLayers(mainCanvas); }
+  }
+
+  const offsets = { ground: 0 };
+
+  function drawParallax(ctx) {
+    const gY = typeof groundY === 'function' ? groundY() : canvasH * 0.82;
+    layers.forEach(l => {
+      let x = l.x;
+      const y = gY - l.height;
+      while (x < canvasW) {
+        ctx.drawImage(l.canvas, x, y);
+        x += l.width;
+      }
+    });
+  }
+
+  function drawGround(ctx) {
+    const gY = typeof groundY === 'function' ? groundY() : canvasH * 0.82;
+    if (!groundPattern) return;
+    ctx.save();
+    ctx.translate(offsets.ground, 0);
+    ctx.fillStyle = groundPattern;
+    ctx.fillRect(-groundPatternSize, gY, canvasW + groundPatternSize, canvasH - gY);
+    ctx.restore();
+    const grad = ctx.createLinearGradient(0, gY - 10, 0, gY + 10);
+    grad.addColorStop(0, 'rgba(0,0,0,0.3)');
+    grad.addColorStop(1, 'rgba(0,0,0,0)');
+    ctx.fillStyle = grad;
+    ctx.fillRect(0, gY - 10, canvasW, 10);
+  }
+
+  return { initBackgroundLayers, updateBackground, drawParallax, drawGround };
+})();

--- a/game.js
+++ b/game.js
@@ -20,6 +20,7 @@
     ctx.setTransform(dpr * SCALE, 0, 0, dpr * SCALE, 0, 0);
     W = canvas.width / (dpr * SCALE);
     H = canvas.height / (dpr * SCALE);
+    if (Bg && Bg.initBackgroundLayers) Bg.initBackgroundLayers(canvas);
   }
   window.addEventListener('resize', resizeCanvas);
   resizeCanvas();
@@ -123,6 +124,7 @@
   const STATE = { MENU:0, PLAY:1, OVER:2 };
   let state = STATE.MENU;
   let time = 0, startTs = 0, lastTs = 0, speed = 400; // px/s base ground speed
+  window._gameSpeed = () => speed;
   let groundY = () => H*0.82;
   let score = 0, best = parseFloat(localStorage.getItem('runnerHighScore') || '0') || 0;
   bestEl.textContent = best.toFixed(1);
@@ -983,6 +985,7 @@
   requestAnimationFrame(loop);
 
   function update(dt){
+    Bg.updateBackground(dt);
     if (enTransicion) {
       progresoTransicion += dt;
       const cx = W/2, cy = H/2;
@@ -1108,21 +1111,6 @@
       drawStars();
       drawMoon(ctx, W*0.8, H*0.22, 40);
       cosmics.forEach(o=>o.render(ctx));
-      // Suelo carretera
-      ctx.fillStyle = '#2C2C2C';
-      ctx.fillRect(0, groundY(), W, H-groundY());
-      // Borde superior del camino
-      ctx.fillStyle = '#444444';
-      ctx.fillRect(0, groundY()-2, W, 2);
-      const roadCenterY = groundY() + (H - groundY()) / 2;
-      ctx.strokeStyle = '#FFDD00';
-      ctx.lineWidth = 4;
-      ctx.beginPath();
-      for (let x = -((time*speed)%120); x < W; x += 60) {
-        ctx.moveTo(x, roadCenterY);
-        ctx.lineTo(x+30, roadCenterY);
-      }
-      ctx.stroke();
     } else {
       // Cielo onírico
       const grad = ctx.createLinearGradient(0,0,0,H);
@@ -1133,7 +1121,12 @@
       drawStars();
       drawSaturn(ctx, W*0.18, H*0.22, 40);
       cosmics.forEach(o=>o.render(ctx));
-      drawRockyGround(ctx);
+    }
+
+    Bg.drawParallax(ctx);
+    Bg.drawGround(ctx);
+
+    if (cicloActual !== 0) {
       // partículas flotantes
       ctx.fillStyle = 'rgba(255,255,255,0.25)';
       particulasOniricas.forEach(p => {

--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
   </div>
   <div id="rotateOverlay">Gira tu teléfono para jugar en horizontal 📲</div>
   <button id="jumpBtn" class="jump-btn">SALTAR ⤴</button>
+  <script src="background.js"></script>
   <script src="game.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add standalone background module with textured ground and three parallax mountain layers
- hook background into canvas resize, update loop and render sequence
- optimize with offscreen canvases and dynamic resolution for low FPS

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b9d0921a0883209f22d4d14ec15a0f