### PR TITLE
Remove random planet and galaxy cosmics

### DIFF
--- a/game.js
+++ b/game.js
@@ -708,11 +708,11 @@
       ctx.fillRect(-14, -3, 28, 6);
       ctx.fillStyle = '#f33';
       ctx.beginPath();
-      ctx.moveTo(14, 0); ctx.lineTo(22, -5); ctx.lineTo(22, 5); ctx.closePath(); ctx.fill();
+      ctx.moveTo(-14, 0); ctx.lineTo(-22, -5); ctx.lineTo(-22, 5); ctx.closePath(); ctx.fill();
       // estela
       ctx.strokeStyle = 'rgba(255,200,200,.5)';
       ctx.beginPath();
-      ctx.moveTo(-14,0); ctx.lineTo(-28, Math.sin(time*60)*3); ctx.stroke();
+      ctx.moveTo(-22,0); ctx.lineTo(-36, Math.sin(time*60)*3); ctx.stroke();
       ctx.restore();
     }
     bbox(){ return {x:this.x-14, y:this.y-5, w:28, h:10}; }

--- a/game.js
+++ b/game.js
@@ -348,12 +348,13 @@
 
   class Cosmic {
     constructor(type = null, giant = false){
-      const baseTypes = ['nebula','comet'];
+      const baseTypes = ['comet'];
       this.type = type || (Math.random() < 0.1 ? 'ufo' : baseTypes[Math.floor(Math.random()*baseTypes.length)]);
       this.giant = giant;
+      this.permanent = giant && this.type === 'nebula';
       this.x = giant ? W/2 : rand(0, W);
       this.y = giant ? H/2 : rand(0, H*0.4);
-      this.ttl = giant ? 4 : 2.5;
+      this.ttl = this.permanent ? Infinity : (giant ? 4 : 2.5);
       if (this.type === 'comet' || this.type === 'ufo') {
         this.x = -50;
         this.y = rand(0, H*0.3);
@@ -362,7 +363,7 @@
       }
     }
     update(dt){
-      this.ttl -= dt;
+      if (!this.permanent) this.ttl -= dt;
       if (this.vx) this.x += this.vx * dt;
     }
     render(ctx){
@@ -370,11 +371,12 @@
       ctx.translate(this.x, this.y);
       switch(this.type){
         case 'nebula':
-          const g = ctx.createRadialGradient(0,0,0,0,0,40);
+          const radius = this.giant ? 120 : 40;
+          const g = ctx.createRadialGradient(0,0,0,0,0,radius);
           g.addColorStop(0,'rgba(255,200,255,0.6)');
           g.addColorStop(1,'rgba(100,0,150,0)');
           ctx.fillStyle = g;
-          ctx.beginPath(); ctx.arc(0,0,40,0,Math.PI*2); ctx.fill();
+          ctx.beginPath(); ctx.arc(0,0,radius,0,Math.PI*2); ctx.fill();
           break;
         case 'blackhole':
           const r = this.giant ? 60 : 25;
@@ -409,7 +411,7 @@
       }
       ctx.restore();
     }
-    get alive(){ return this.ttl > 0; }
+    get alive(){ return this.permanent || this.ttl > 0; }
   }
 
   function clearEnemies(){
@@ -884,6 +886,10 @@
       }));
     } else {
       particulasOniricas = [];
+    }
+
+    if (cicloActual === 1) {
+      cosmics.push(new Cosmic('nebula', true));
     }
   }
 

--- a/game.js
+++ b/game.js
@@ -348,7 +348,7 @@
 
   class Cosmic {
     constructor(type = null, giant = false){
-      const baseTypes = ['galaxy','planet','nebula','comet'];
+      const baseTypes = ['nebula','comet'];
       this.type = type || (Math.random() < 0.1 ? 'ufo' : baseTypes[Math.floor(Math.random()*baseTypes.length)]);
       this.giant = giant;
       this.x = giant ? W/2 : rand(0, W);
@@ -360,11 +360,6 @@
         this.vx = this.type === 'comet' ? rand(150,220) : rand(60,90);
         this.ttl = (W + 100) / this.vx;
       }
-      if (this.type === 'planet') {
-        this.r = rand(10,20);
-        const hue = Math.floor(rand(0,360));
-        this.color = `hsl(${hue},60%,60%)`;
-      }
     }
     update(dt){
       this.ttl -= dt;
@@ -374,21 +369,6 @@
       ctx.save();
       ctx.translate(this.x, this.y);
       switch(this.type){
-        case 'galaxy':
-          ctx.strokeStyle = 'rgba(200,200,255,0.6)';
-          ctx.lineWidth = 1.5;
-          for (let arm = 0; arm < 4; arm++) {
-            ctx.beginPath();
-            for (let t = 0; t < Math.PI * 2; t += 0.2) {
-              const rad = t * 2;
-              const ang = t + arm * (Math.PI / 2);
-              ctx.lineTo(Math.cos(ang) * rad, Math.sin(ang) * rad);
-            }
-            ctx.stroke();
-          }
-          ctx.fillStyle = '#fff';
-          ctx.beginPath(); ctx.arc(0,0,3,0,Math.PI*2); ctx.fill();
-          break;
         case 'nebula':
           const g = ctx.createRadialGradient(0,0,0,0,0,40);
           g.addColorStop(0,'rgba(255,200,255,0.6)');
@@ -412,12 +392,6 @@
           ctx.strokeStyle = 'rgba(0,120,255,0.9)';
           ctx.lineWidth = this.giant ? 8 : 4;
           ctx.beginPath(); ctx.arc(0,0,r + (this.giant ? 8 : 4),0,Math.PI*2); ctx.stroke();
-          break;
-        case 'planet':
-          ctx.fillStyle = this.color;
-          ctx.beginPath(); ctx.arc(0,0,this.r,0,Math.PI*2); ctx.fill();
-          ctx.strokeStyle = 'rgba(255,255,255,0.2)';
-          ctx.lineWidth = 2; ctx.stroke();
           break;
         case 'comet':
           ctx.strokeStyle = 'rgba(255,255,255,0.5)';

--- a/game.js
+++ b/game.js
@@ -349,13 +349,13 @@
   }
 
   class Cosmic {
-    constructor(type = null, giant = false){
+    constructor(type = null, giant = false, x = null, y = null){
       const baseTypes = ['comet'];
       this.type = type || (Math.random() < 0.1 ? 'ufo' : baseTypes[Math.floor(Math.random()*baseTypes.length)]);
       this.giant = giant;
       this.permanent = giant && this.type === 'nebula';
-      this.x = giant ? W/2 : rand(0, W);
-      this.y = giant ? H/2 : rand(0, H*0.4);
+      this.x = x !== null ? x : (giant ? W/2 : rand(0, W));
+      this.y = y !== null ? y : (giant ? H/2 : rand(0, H*0.4));
       this.ttl = this.permanent ? Infinity : (giant ? 4 : 2.5);
       if (this.type === 'comet' || this.type === 'ufo') {
         this.x = -50;
@@ -919,7 +919,7 @@
     }
 
     if (cicloActual === 1) {
-      cosmics.push(new Cosmic('nebula', true));
+      cosmics.push(new Cosmic('nebula', true, W*0.82, H*0.22));
     }
   }
 
@@ -1105,6 +1105,7 @@
         d.alive = false;
         lives += 1;
         livesEl.textContent = lives;
+        flashBadge('+1 ♥');
         Audio.shield();
       }
     });

--- a/game.js
+++ b/game.js
@@ -542,8 +542,8 @@
       const dx = t.x - this.x, dy = t.y - this.y;
       const d = Math.hypot(dx, dy) || 1;
       const spd = 260;
-      const vx = (dx / d) * spd;
-      const vy = (dy / d) * spd;
+      const vx = -(dx / d) * spd;
+      const vy = -(dy / d) * spd;
       const homing = time >= 180 ? (missileHomingToggle = !missileHomingToggle) : false;
       missiles.push(new Missile(this.x, this.y, vx, vy, homing));
       this.fired = true;
@@ -691,18 +691,18 @@
         const dx = t.x - this.x, dy = t.y - this.y;
         const d = Math.hypot(dx, dy) || 1;
         const ux = dx / d, uy = dy / d;
-        this.vx = this.vx * 0.9 + this.speed * ux * 0.1;
-        this.vy = this.vy * 0.9 + this.speed * uy * 0.1;
+        this.vx = this.vx * 0.9 - this.speed * ux * 0.1;
+        this.vy = this.vy * 0.9 - this.speed * uy * 0.1;
       }
-      this.x += this.vx * dt;
-      this.y += this.vy * dt;
+      this.x -= this.vx * dt;
+      this.y -= this.vy * dt;
       if (this.x < -40 || this.x > W + 40 || this.y < -40 || this.y > H + 40) this.alive = false;
     }
     render(ctx) {
       // misil simple
       ctx.save();
       ctx.translate(this.x, this.y);
-      const ang = Math.atan2(this.vy, this.vx);
+      const ang = Math.atan2(-this.vy, -this.vx);
       ctx.rotate(ang);
       ctx.fillStyle = '#ddd';
       ctx.fillRect(-14, -3, 28, 6);


### PR DESCRIPTION
## Summary
- prevent transient planets and galaxies from spawning by limiting cosmic types to nebulae and comets
- remove unused planet/galaxy rendering code

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68bbd0d05fb883208f8c79b79397b378